### PR TITLE
Adding archived repository notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ OCM SMTP Service
 
 This project is an SMTP credential management service for RHMI
 
+## *** NOTICE ***
+This Github repository has been archived and migrated to [Gitlab](https://gitlab.cee.redhat.com/service/ocm-sendgrid-service)
+
 ## SMTP Management OpenAPI 
 [SMTP Management OpenAPI Documentation](./pkg/api/openapi/README.md)
 


### PR DESCRIPTION
**Summary**
As the SendGrid service has been migrated to Gitlab, we need to add a note to the README to inform users to this change.

Once merged we can archive the repository formally.